### PR TITLE
Type fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaleidawave/prism",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Isomorphic web app compiler",
   "main": "out/index.js",
   "scripts": {

--- a/tests/chef/javascript/javascript.parse.test.ts
+++ b/tests/chef/javascript/javascript.parse.test.ts
@@ -2025,6 +2025,35 @@ describe("Typescript", () => {
                 { name: "string" },
             ]);
         });
+
+        test("Literal types", () => {
+            const typeAlias = Module.fromString("type abcString = 'abc'").statements[0] as TypeStatement;
+
+            expect(typeAlias.value.value).toBeDefined();
+            expect(typeAlias.value.value).toBeInstanceOf(Value);
+            expect(typeAlias.value.value!.type).toBe(Type.string);
+            expect(typeAlias.value.value!.value).toBe("abc");
+        });
+
+        test("Union types", () => {
+            const typeAlias = Module.fromString("type aOrB = a | b").statements[0] as TypeStatement;
+
+            expect(typeAlias.value.name).toBe("Union");
+            expect(typeAlias.value.typeArguments).toMatchObject([
+                { name: "a" },
+                { name: "b" },
+            ]);
+        });
+
+        test("Intersection types", () => {
+            const typeAlias = Module.fromString("type aAndBIntersection = a & b").statements[0] as TypeStatement;
+
+            expect(typeAlias.value.name).toBe("Intersection");
+            expect(typeAlias.value.typeArguments).toMatchObject([
+                { name: "a" },
+                { name: "b" },
+            ]);
+        }); 
     });
 });
 

--- a/tests/chef/javascript/javascript.render.test.ts
+++ b/tests/chef/javascript/javascript.render.test.ts
@@ -747,7 +747,7 @@ describe("Type signatures", () => {
         expect(ts.render(typescriptSettings)).toBe("Array<string>");
     });
 
-    test("Type union", () => {
+    test("Union type", () => {
         const ts = new TypeSignature({
             name: "Union", typeArguments: [
                 new TypeSignature("string"),
@@ -755,6 +755,24 @@ describe("Type signatures", () => {
         });
 
         expect(ts.render(typescriptSettings)).toBe("string | number");
+    });
+
+    test("Intersection type", () => {
+        const ts = new TypeSignature({
+            name: "Intersection", typeArguments: [
+                new TypeSignature("a"),
+                new TypeSignature("b")]
+        });
+
+        expect(ts.render(typescriptSettings)).toBe("a & b");
+    });
+
+    test("Literal type", () => {
+        const ts = new TypeSignature({
+            value: new Value("abc", Type.string)
+        });
+
+        expect(ts.render(typescriptSettings)).toBe(`"abc"`);
     });
 
     test("Tuple type", () => {

--- a/tests/chef/javascript/javascript.render.test.ts
+++ b/tests/chef/javascript/javascript.render.test.ts
@@ -19,6 +19,7 @@ import { TypeSignature } from "../../../src/chef/javascript/components/types/typ
 import { TryBlock, CatchBlock } from "../../../src/chef/javascript/components/statements/try-catch";
 import { SwitchStatement } from "../../../src/chef/javascript/components/statements/switch";
 import { InterfaceDeclaration } from "../../../src/chef/javascript/components/types/interface";
+import { EnumDeclaration } from "../../../src/chef/javascript/components/types/enum";
 
 const minificationSettings = getSettings({ minify: true });
 const typescriptSettings = getSettings({ scriptLanguage: ScriptLanguages.Typescript, minify: true });
@@ -732,6 +733,26 @@ describe("Interfaces", () => {
     });
 
     test.todo("Function type");
+});
+
+describe("Enums", () => {
+    test("Enum", () => {
+        const enum_ = new EnumDeclaration("X", new Map([
+            ["A", new Value("0", Type.number)],
+            ["B", new Value("1", Type.number)],
+        ]));
+
+        expect(enum_.render(typescriptSettings)).toBe("enum X {\n    A,\n    B\n}\n");
+    });
+    
+    test("Render enum to JS object", () => {
+        const enum_ = new EnumDeclaration("X", new Map([
+            ["A", new Value("0", Type.number)],
+            ["B", new Value("1", Type.number)],
+        ]));
+    
+        expect(enum_.render(minificationSettings)).toBe("const X=Object.freeze({A:0,B:1})");
+    });
 });
 
 describe("Type signatures", () => {


### PR DESCRIPTION
Fixes issues #1, #2, #3, #4

- Fixes string and number literal types
- Implements [intersection types](https://www.typescriptlang.org/docs/handbook/unions-and-intersections.html#intersection-types)
- Renders out ts enums as js objects for compat
- Enums are now resolved to be number or string types

Should allow for use of enum use in prism templates.